### PR TITLE
feat: log skipped news items

### DIFF
--- a/src/alpaca.rs
+++ b/src/alpaca.rs
@@ -2,7 +2,7 @@ use crate::config::Settings;
 use crate::discord::{
     WebhookPayload, analyst_payload, earnings_payload, news_payload, send_payload,
 };
-use crate::news::{NewsItem, NewsKind, accepted_symbol, classify};
+use crate::news::{NewsItem, NewsKind, SkipReason, accepted_symbol, classify, skip_reason};
 use futures_util::{SinkExt, StreamExt};
 use html_escape::decode_html_entities;
 use serde_json::{Value, json};
@@ -112,6 +112,10 @@ async fn handle_message(
     settings: &Settings,
     mut item: NewsItem,
 ) -> AppResult<()> {
+    if let Some(reason) = skip_reason(&item) {
+        log_skip(reason, &item);
+        return Ok(());
+    }
     let Some(symbol) = accepted_symbol(&item).map(str::to_string) else {
         return Ok(());
     };
@@ -151,6 +155,24 @@ async fn handle_message(
         None => {}
     }
     Ok(())
+}
+
+fn log_skip(reason: SkipReason, item: &NewsItem) {
+    let symbol = item.symbols.first().map(String::as_str).unwrap_or("");
+    match reason {
+        SkipReason::SymbolCount => {
+            info!(symbols = ?item.symbols, author = %item.author, headline = %item.headline, "skipping news without exactly one symbol")
+        }
+        SkipReason::EmptySymbol => {
+            info!(author = %item.author, headline = %item.headline, "skipping news with empty symbol")
+        }
+        SkipReason::NonUsExchange => {
+            info!(%symbol, author = %item.author, headline = %item.headline, "skipping non-US exchange")
+        }
+        SkipReason::UnapprovedAuthor => {
+            info!(%symbol, author = %item.author, headline = %item.headline, "skipping non-approved author")
+        }
+    }
 }
 
 async fn send_or_log(client: &reqwest::Client, webhooks: &[String], payload: &WebhookPayload) {

--- a/src/news.rs
+++ b/src/news.rs
@@ -22,11 +22,32 @@ pub enum NewsKind {
     News,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkipReason {
+    SymbolCount,
+    EmptySymbol,
+    NonUsExchange,
+    UnapprovedAuthor,
+}
+
 pub fn accepted_symbol(item: &NewsItem) -> Option<&str> {
     let [symbol] = item.symbols.as_slice() else {
         return None;
     };
     (!symbol.trim().is_empty() && !symbol.contains(':')).then_some(symbol.as_str())
+}
+
+pub fn skip_reason(item: &NewsItem) -> Option<SkipReason> {
+    let [symbol] = item.symbols.as_slice() else {
+        return Some(SkipReason::SymbolCount);
+    };
+    if symbol.trim().is_empty() {
+        return Some(SkipReason::EmptySymbol);
+    }
+    if symbol.contains(':') {
+        return Some(SkipReason::NonUsExchange);
+    }
+    (!is_allowed_author(item)).then_some(SkipReason::UnapprovedAuthor)
 }
 
 pub fn is_allowed_author(item: &NewsItem) -> bool {
@@ -81,6 +102,30 @@ mod tests {
         assert_eq!(
             accepted_symbol(&item(&[""], "Benzinga Newsdesk", "headline")),
             None
+        );
+    }
+
+    #[test]
+    fn explains_skipped_items() {
+        assert_eq!(
+            skip_reason(&item(&["AAPL", "MSFT"], "Benzinga Newsdesk", "headline")),
+            Some(SkipReason::SymbolCount)
+        );
+        assert_eq!(
+            skip_reason(&item(&[""], "Benzinga Newsdesk", "headline")),
+            Some(SkipReason::EmptySymbol)
+        );
+        assert_eq!(
+            skip_reason(&item(&["TSX:SHOP"], "Benzinga Newsdesk", "headline")),
+            Some(SkipReason::NonUsExchange)
+        );
+        assert_eq!(
+            skip_reason(&item(
+                &["AAPL"],
+                "Someone Else",
+                "AAPL Q1 EPS $2.00 vs $1.80 est."
+            )),
+            Some(SkipReason::UnapprovedAuthor)
         );
     }
 


### PR DESCRIPTION
## What
- log news items skipped by symbol count, empty symbol, non-US exchange, or unapproved author
- add a small skip-reason test so parser visibility does not regress

## Testing
- `make check`
- `make coverage`
- CodeRabbit local review: 0 findings
