### PR TITLE
fix: reconnect news stream on stalled or dead connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ regex = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time"] }
 tokio-tungstenite = { version = "0.28", features = ["rustls-tls-webpki-roots"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/src/alpaca.rs
+++ b/src/alpaca.rs
@@ -27,6 +27,10 @@ const READ_TIMEOUT: Duration = Duration::from_secs(120);
 /// Backoff between reconnect attempts so a persistent outage doesn't spin
 /// the CPU or hammer Alpaca with connection attempts.
 const RECONNECT_DELAY: Duration = Duration::from_secs(5);
+/// Cap on Discord webhook requests. Without this, a stalled POST blocks
+/// `handle_message` (and therefore the websocket read loop) indefinitely,
+/// defeating the read timeout above.
+const DISCORD_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Reconnects to the news stream whenever it errors out or ends, instead of
 /// letting a single disconnect (or a stalled connection) stop the whole
@@ -70,7 +74,9 @@ async fn stream_news(settings: &Settings) -> AppResult<()> {
     expect_success(&mut read, "subscription").await?;
     info!("subscribed to news successfully");
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(DISCORD_REQUEST_TIMEOUT)
+        .build()?;
     let mut ping_interval = interval(PING_INTERVAL);
     ping_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
     ping_interval.tick().await; // first tick fires immediately; skip it

--- a/src/alpaca.rs
+++ b/src/alpaca.rs
@@ -6,12 +6,41 @@ use crate::news::{NewsItem, NewsKind, SkipReason, accepted_symbol, classify, ski
 use futures_util::{SinkExt, StreamExt};
 use html_escape::decode_html_entities;
 use serde_json::{Value, json};
+use std::time::Duration;
+use tokio::time::{Instant, MissedTickBehavior, interval, sleep};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{debug, info, warn};
 
 pub type AppResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
-pub async fn stream_news(settings: &Settings) -> AppResult<()> {
+/// How often we proactively ping the server. This also flushes any
+/// automatic pong replies tungstenite queued on our behalf, since those
+/// only go out when the write half is polled.
+const PING_INTERVAL: Duration = Duration::from_secs(30);
+/// How long we tolerate silence (no message, ping tick, or pong) before
+/// treating the connection as dead and forcing a reconnect. A live feed
+/// legitimately goes quiet for hours outside market hours, but a dead TCP
+/// connection with no FIN/RST looks identical to `read.next()` forever,
+/// so this timeout is the only way to detect it. Reset only when a frame
+/// actually arrives, not on every loop iteration.
+const READ_TIMEOUT: Duration = Duration::from_secs(120);
+/// Backoff between reconnect attempts so a persistent outage doesn't spin
+/// the CPU or hammer Alpaca with connection attempts.
+const RECONNECT_DELAY: Duration = Duration::from_secs(5);
+
+/// Reconnects to the news stream whenever it errors out or ends, instead of
+/// letting a single disconnect (or a stalled connection) stop the whole
+/// process from sending Discord alerts.
+pub async fn run(settings: &Settings) {
+    loop {
+        if let Err(error) = stream_news(settings).await {
+            warn!(%error, "news stream disconnected, reconnecting");
+        }
+        sleep(RECONNECT_DELAY).await;
+    }
+}
+
+async fn stream_news(settings: &Settings) -> AppResult<()> {
     let (ws, _) = connect_async(&settings.alpaca_news_stream_url).await?;
     let (mut write, mut read) = ws.split();
 
@@ -42,15 +71,35 @@ pub async fn stream_news(settings: &Settings) -> AppResult<()> {
     info!("subscribed to news successfully");
 
     let client = reqwest::Client::new();
-    while let Some(message) = read.next().await {
-        let Message::Text(text) = message? else {
-            continue;
-        };
-        for item in news_items_from_frame(&text) {
-            handle_message(&client, settings, item).await?;
+    let mut ping_interval = interval(PING_INTERVAL);
+    ping_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    ping_interval.tick().await; // first tick fires immediately; skip it
+
+    let read_deadline = sleep(READ_TIMEOUT);
+    tokio::pin!(read_deadline);
+
+    loop {
+        tokio::select! {
+            _ = ping_interval.tick() => {
+                write.send(Message::Ping(Vec::new().into())).await?;
+            }
+            () = &mut read_deadline => {
+                return Err("no messages received within timeout, reconnecting".into());
+            }
+            message = read.next() => {
+                read_deadline.as_mut().reset(Instant::now() + READ_TIMEOUT);
+                let Some(message) = message else {
+                    return Err("websocket closed".into());
+                };
+                let Message::Text(text) = message? else {
+                    continue;
+                };
+                for item in news_items_from_frame(&text) {
+                    handle_message(&client, settings, item).await?;
+                }
+            }
         }
     }
-    Ok(())
 }
 
 async fn expect_success<S>(read: &mut S, action: &str) -> AppResult<()>

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use stocknews::{alpaca::stream_news, config::Settings};
+use stocknews::{alpaca::run, config::Settings};
 
 #[tokio::main]
 async fn main() -> stocknews::alpaca::AppResult<()> {
@@ -6,10 +6,7 @@ async fn main() -> stocknews::alpaca::AppResult<()> {
     let settings = Settings::from_env()?;
 
     tokio::select! {
-        result = stream_news(&settings) => result,
-        signal = tokio::signal::ctrl_c() => {
-            signal?;
-            Ok(())
-        }
+        () = run(&settings) => Ok(()),
+        signal = tokio::signal::ctrl_c() => signal.map_err(Into::into),
     }
 }


### PR DESCRIPTION
## What

The bot stopped sending anything to Discord. The deployed pod had been running for over a week with no crashes, no restarts, and no log output at all — it just silently stopped processing news.

`stream_news()` had no heartbeat and no read timeout, so when the underlying TCP connection died without a clean close (no FIN/RST — common behind load balancers/NAT for long-lived connections), `read.next().await` blocked forever with no error and no logs. `main.rs` also only called `stream_news()` once, so even a clean error would have ended the whole process instead of reconnecting.

## Fix

- Ping the websocket every 30s (this also flushes tungstenite's automatically-queued pong replies, which otherwise never go out since we split the read/write halves and only poll the write side to ping).
- Track a 120s read deadline that resets whenever a frame actually arrives, and error out to force a reconnect if it elapses.
- Add `alpaca::run()`, which loops `stream_news()` with a 5s backoff so any disconnect (including the new timeout) reconnects instead of ending the process. `main.rs` now just calls it.

## Testing

- `make check` (fmt, clippy, tests, `cargo deny`, `cargo machete`) — all green.
