### PR TITLE
feat: log git sha and build date at startup

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -43,6 +43,8 @@ jobs:
           platforms: linux/amd64
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: ghcr.io/${{ github.repository }}:latest
+          build-args: |
+            GIT_SHA=${{ github.sha }}
 
       - name: Check homehosted token
         if: github.ref == 'refs/heads/main'

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,6 @@
 FROM registry.access.redhat.com/hi/rust:1.96-builder AS builder
+ARG GIT_SHA=unknown
+ENV GIT_SHA=${GIT_SHA}
 WORKDIR /src
 COPY . .
 RUN cargo build --release --locked

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,40 @@
+use std::process::Command;
+
+/// Resolves the git SHA for this build.
+///
+/// Prefers the `GIT_SHA` env var (set via `--build-arg` in container builds,
+/// where the `.git` directory isn't present in the build context) and falls
+/// back to invoking `git` directly for local `cargo build`/`cargo run`.
+fn git_sha() -> String {
+    std::env::var("GIT_SHA")
+        .ok()
+        .filter(|sha| !sha.is_empty())
+        .or_else(|| {
+            Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .ok()
+                .filter(|output| output.status.success())
+                .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        })
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Resolves the UTC build timestamp using the `date` binary, which is
+/// available in the container builder image and on developer machines.
+fn build_date() -> String {
+    Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn main() {
+    println!("cargo:rustc-env=GIT_SHA={}", git_sha());
+    println!("cargo:rustc-env=BUILD_DATE={}", build_date());
+    println!("cargo:rerun-if-env-changed=GIT_SHA");
+    println!("cargo:rerun-if-changed=.git/HEAD");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,12 @@ async fn main() -> stocknews::alpaca::AppResult<()> {
         .with(sentry::integrations::tracing::layer())
         .init();
 
+    tracing::info!(
+        git_sha = env!("GIT_SHA"),
+        build_date = env!("BUILD_DATE"),
+        "starting stocknews"
+    );
+
     tokio::select! {
         () = run(&settings) => Ok(()),
         signal = tokio::signal::ctrl_c() => signal.map_err(Into::into),


### PR DESCRIPTION
When something goes wrong in the kubernetes deployment, the logs currently don't say which commit or build is actually running, which makes it slow to correlate an incident with a specific release. This adds a git SHA and build timestamp to the very first log line on startup.

- add `build.rs` to capture `GIT_SHA` and `BUILD_DATE` at compile time — it prefers a `GIT_SHA` env var (for container builds, since `.dockerignore` excludes `.git` from the build context) and falls back to `git rev-parse HEAD` for local `cargo build`/`cargo run`
- log both fields via `tracing::info!` right after the subscriber initializes, so it's the first thing written to stdout
- pass `GIT_SHA` as a container build-arg from the `container.yml` workflow using `github.sha`, so images built in CI embed the real commit

Verified with `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo deny check`, `cargo machete`, and a local `podman build`/`podman run` confirming the log line shows the right `git_sha` and `build_date`.
