### PR TITLE
fix: decode HTML entities before logging skipped news

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ lcov.info
 .env
 .vscode/
 .idea/
+
+# deepwork scratch state (not part of repo)
+.slim/deepwork/

--- a/src/alpaca.rs
+++ b/src/alpaca.rs
@@ -167,6 +167,9 @@ async fn handle_message(
     settings: &Settings,
     mut item: NewsItem,
 ) -> AppResult<()> {
+    if let std::borrow::Cow::Owned(decoded) = decode_html_entities(&item.headline) {
+        item.headline = decoded;
+    }
     if let Some(reason) = skip_reason(&item) {
         log_skip(reason, &item);
         return Ok(());
@@ -175,7 +178,6 @@ async fn handle_message(
         return Ok(());
     };
 
-    item.headline = decode_html_entities(&item.headline).into_owned();
     match classify(&item) {
         Some(NewsKind::Earnings) => {
             info!(%symbol, headline = %item.headline, "earnings news");


### PR DESCRIPTION
Some skipped-news log lines showed raw HTML entities like `&#39;` instead of a plain apostrophe, even though headlines sent to Discord were already clean. The decode call ran after the skip-reason check, so `log_skip` printed the undecoded headline for anything filtered out before that point (unapproved author, non-US exchange, wrong symbol count, etc).

- move `decode_html_entities` to the top of `handle_message`, before any skip checks, so every logged headline is decoded regardless of whether the item is skipped or sent

Also drops a stray `.slim/deepwork/` scratch dir into `.gitignore` (unrelated cleanup from a prior session, included since it was already committed).

Verified with `make check` (fmt, clippy, tests, `cargo deny`, `cargo machete`) — all green, 34/34 tests pass.
