### PR TITLE
refactor(analyst): clean up top rust code smells

### DIFF
--- a/src/analyst.rs
+++ b/src/analyst.rs
@@ -21,14 +21,17 @@ impl PriceTargetAction {
     }
 }
 
-static MAINTAINS_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)^([\w\s]+) (Maintains|Reiterates) (.*) on (.+),").unwrap());
-static ACTION_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)^([\w\s]+) (Downgrades|Upgrades|Initiates Coverage) (?:on\s)*([\w\s]+) (?:with|to) (.+),").unwrap()
+static MAINTAINS_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)^(?P<firm>[\w\s]+) (?P<action>Maintains|Reiterates) (?P<guidance>.*) on (?P<stock>.+),")
+        .unwrap()
 });
-static PRICE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\$([\d\.]+)").unwrap());
+static ACTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)^(?P<firm>[\w\s]+) (?P<action>Downgrades|Upgrades|Initiates Coverage) (?:on\s)*(?P<stock>[\w\s]+) (?:with|to) (?P<guidance>.+),")
+        .unwrap()
+});
+static PRICE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\$(?P<price>[\d\.]+)").unwrap());
 static PRICE_ACTION_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r", (Lowers|Maintains|Raises|Announces)").unwrap());
+    LazyLock::new(|| Regex::new(r", (?P<price_action>Lowers|Maintains|Raises|Announces)").unwrap());
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct AnalystNews {
@@ -43,28 +46,34 @@ pub struct AnalystNews {
 
 fn parse_analyst_action(headline: &str) -> (String, String, String, String) {
     if let Some(captures) = MAINTAINS_RE.captures(headline) {
-        let firm = captures[1].to_string();
-        let action = captures[2].to_string();
-        let guidance = captures[3].trim_end_matches("Rating").trim().to_string();
-        let stock = captures[4].to_string();
+        let firm = captures["firm"].to_string();
+        let action = captures["action"].to_string();
+        let guidance = captures["guidance"]
+            .trim_end_matches("Rating")
+            .trim()
+            .to_string();
+        let stock = captures["stock"].to_string();
         return (firm, action, guidance, stock);
     }
 
     if let Some(captures) = ACTION_RE.captures(headline) {
-        let firm = captures[1].to_string();
-        let action = captures[2].to_string();
-        let stock = captures[3].to_string();
-        let guidance = captures[4].trim_end_matches("Rating").trim().to_string();
+        let firm = captures["firm"].to_string();
+        let action = captures["action"].to_string();
+        let stock = captures["stock"].to_string();
+        let guidance = captures["guidance"]
+            .trim_end_matches("Rating")
+            .trim()
+            .to_string();
         return (firm, action, guidance, stock);
     }
 
     (String::new(), String::new(), String::new(), String::new())
 }
 
-fn extract_value(headline: &str, regex: &Regex) -> String {
+fn extract_value(headline: &str, regex: &Regex, name: &str) -> String {
     regex
         .captures(headline)
-        .map(|captures| captures[1].to_string())
+        .map(|captures| captures[name].to_string())
         .unwrap_or_default()
 }
 
@@ -72,12 +81,12 @@ impl AnalystNews {
     pub fn new(headline: impl Into<String>) -> Self {
         let headline = headline.into();
         let (firm, action, guidance, stock) = parse_analyst_action(&headline);
-        let price_target = extract_value(&headline, &PRICE_RE)
+        let price_target = extract_value(&headline, &PRICE_RE, "price")
             .parse::<f64>()
             .unwrap_or_default();
         let price_target_action = PRICE_ACTION_RE
             .captures(&headline)
-            .and_then(|captures| PriceTargetAction::from_captured_str(&captures[1]));
+            .and_then(|captures| PriceTargetAction::from_captured_str(&captures["price_action"]));
         Self {
             headline,
             firm,

--- a/src/analyst.rs
+++ b/src/analyst.rs
@@ -30,7 +30,7 @@ static PRICE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\$([\d\.]+)").u
 static PRICE_ACTION_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r", (Lowers|Maintains|Raises|Announces)").unwrap());
 
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AnalystNews {
     pub headline: String,
     pub firm: String,
@@ -41,49 +41,52 @@ pub struct AnalystNews {
     pub price_target: f64,
 }
 
+fn parse_analyst_action(headline: &str) -> (String, String, String, String) {
+    if let Some(captures) = MAINTAINS_RE.captures(headline) {
+        let firm = captures[1].to_string();
+        let action = captures[2].to_string();
+        let guidance = captures[3].trim_end_matches("Rating").trim().to_string();
+        let stock = captures[4].to_string();
+        return (firm, action, guidance, stock);
+    }
+
+    if let Some(captures) = ACTION_RE.captures(headline) {
+        let firm = captures[1].to_string();
+        let action = captures[2].to_string();
+        let stock = captures[3].to_string();
+        let guidance = captures[4].trim_end_matches("Rating").trim().to_string();
+        return (firm, action, guidance, stock);
+    }
+
+    (String::new(), String::new(), String::new(), String::new())
+}
+
+fn extract_value(headline: &str, regex: &Regex) -> String {
+    regex
+        .captures(headline)
+        .map(|captures| captures[1].to_string())
+        .unwrap_or_default()
+}
+
 impl AnalystNews {
     pub fn new(headline: impl Into<String>) -> Self {
-        let mut news = Self {
-            headline: headline.into(),
-            ..Self::default()
-        };
-        news.parse();
-        news
-    }
-
-    fn parse(&mut self) {
-        self.parse_analyst_action();
-        self.price_target = self
-            .extract_value(&PRICE_RE)
+        let headline = headline.into();
+        let (firm, action, guidance, stock) = parse_analyst_action(&headline);
+        let price_target = extract_value(&headline, &PRICE_RE)
             .parse::<f64>()
             .unwrap_or_default();
-        self.price_target_action = PRICE_ACTION_RE
-            .captures(&self.headline)
+        let price_target_action = PRICE_ACTION_RE
+            .captures(&headline)
             .and_then(|captures| PriceTargetAction::from_captured_str(&captures[1]));
-    }
-
-    fn parse_analyst_action(&mut self) {
-        if let Some(captures) = MAINTAINS_RE.captures(&self.headline) {
-            self.firm = captures[1].to_string();
-            self.action = captures[2].to_string();
-            self.guidance = captures[3].trim_end_matches("Rating").trim().to_string();
-            self.stock = captures[4].to_string();
-            return;
+        Self {
+            headline,
+            firm,
+            action,
+            guidance,
+            stock,
+            price_target,
+            price_target_action,
         }
-
-        if let Some(captures) = ACTION_RE.captures(&self.headline) {
-            self.firm = captures[1].to_string();
-            self.action = captures[2].to_string();
-            self.stock = captures[3].to_string();
-            self.guidance = captures[4].trim_end_matches("Rating").trim().to_string();
-        }
-    }
-
-    fn extract_value(&self, regex: &Regex) -> String {
-        regex
-            .captures(&self.headline)
-            .map(|captures| captures[1].to_string())
-            .unwrap_or_default()
     }
 }
 

--- a/src/analyst.rs
+++ b/src/analyst.rs
@@ -165,6 +165,23 @@ mod tests {
     }
 
     #[test]
+    fn maintains_price_target() {
+        let news = AnalystNews::new(
+            "Morgan Stanley Upgrades Tesla to Overweight, Maintains Price Target at $400",
+        );
+        assert_eq!(news.price_target_action, Some(PriceTargetAction::Maintains));
+    }
+
+    #[test]
+    fn no_analyst_action_match() {
+        let news = AnalystNews::new("Apple releases new iPhone");
+        assert_eq!(news.firm, "");
+        assert_eq!(news.action, "");
+        assert_eq!(news.guidance, "");
+        assert_eq!(news.stock, "");
+    }
+
+    #[test]
     fn strip_rating_suffix() {
         let news = AnalystNews::new(
             "UBS Downgrades Microsoft to Neutral Rating, Lowers Price Target to $275",

--- a/src/analyst.rs
+++ b/src/analyst.rs
@@ -1,6 +1,26 @@
 use regex::Regex;
 use std::sync::LazyLock;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PriceTargetAction {
+    Lowers,
+    Raises,
+    Announces,
+    Maintains,
+}
+
+impl PriceTargetAction {
+    fn from_captured_str(s: &str) -> Option<Self> {
+        match s {
+            "Lowers" => Some(Self::Lowers),
+            "Raises" => Some(Self::Raises),
+            "Announces" => Some(Self::Announces),
+            "Maintains" => Some(Self::Maintains),
+            _ => None,
+        }
+    }
+}
+
 static MAINTAINS_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)^([\w\s]+) (Maintains|Reiterates) (.*) on (.+),").unwrap());
 static ACTION_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -17,7 +37,7 @@ pub struct AnalystNews {
     pub action: String,
     pub guidance: String,
     pub stock: String,
-    pub price_target_action: String,
+    pub price_target_action: Option<PriceTargetAction>,
     pub price_target: f64,
 }
 
@@ -37,7 +57,9 @@ impl AnalystNews {
             .extract_value(&PRICE_RE)
             .parse::<f64>()
             .unwrap_or_default();
-        self.price_target_action = self.extract_value(&PRICE_ACTION_RE);
+        self.price_target_action = PRICE_ACTION_RE
+            .captures(&self.headline)
+            .and_then(|captures| PriceTargetAction::from_captured_str(&captures[1]));
     }
 
     fn parse_analyst_action(&mut self) {
@@ -77,7 +99,7 @@ mod tests {
         assert_eq!(news.action, "Maintains");
         assert_eq!(news.guidance, "Buy");
         assert_eq!(news.stock, "Apple");
-        assert_eq!(news.price_target_action, "Raises");
+        assert_eq!(news.price_target_action, Some(PriceTargetAction::Raises));
         assert_eq!(news.price_target, 223.0);
     }
 
@@ -90,7 +112,7 @@ mod tests {
         assert_eq!(news.action, "Upgrades");
         assert_eq!(news.stock, "Tesla");
         assert_eq!(news.guidance, "Overweight");
-        assert_eq!(news.price_target_action, "Raises");
+        assert_eq!(news.price_target_action, Some(PriceTargetAction::Raises));
         assert_eq!(news.price_target, 400.0);
     }
 
@@ -103,7 +125,7 @@ mod tests {
         assert_eq!(news.action, "Downgrades");
         assert_eq!(news.stock, "Amazon");
         assert_eq!(news.guidance, "Neutral");
-        assert_eq!(news.price_target_action, "Lowers");
+        assert_eq!(news.price_target_action, Some(PriceTargetAction::Lowers));
         assert_eq!(news.price_target, 135.0);
     }
 
@@ -116,8 +138,18 @@ mod tests {
         assert_eq!(news.action, "Initiates Coverage");
         assert_eq!(news.stock, "Nvidia");
         assert_eq!(news.guidance, "Overweight");
-        assert_eq!(news.price_target_action, "Announces");
+        assert_eq!(news.price_target_action, Some(PriceTargetAction::Announces));
         assert_eq!(news.price_target, 850.0);
+    }
+
+    #[test]
+    fn no_price_target_action() {
+        let news = AnalystNews::new(
+            "Goldman Sachs Maintains Buy on Apple, Says Fundamentals Remain Strong",
+        );
+        assert_eq!(news.firm, "Goldman Sachs");
+        assert_eq!(news.stock, "Apple");
+        assert_eq!(news.price_target_action, None);
     }
 
     #[test]

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -173,6 +173,19 @@ mod tests {
     }
 
     #[test]
+    fn builds_analyst_payload_for_lowers() {
+        let payload = analyst_payload(
+            "AMZN",
+            "JPMorgan Downgrades Amazon with Neutral Rating, Lowers Price Target to $135",
+            LOGO,
+            TRANSPARENT,
+        )
+        .unwrap();
+        assert_eq!(payload.embeds[0].title, "💔 AMZN: Amazon $135.00");
+        assert_eq!(payload.embeds[0].color, Some(0xd42020));
+    }
+
+    #[test]
     fn builds_analyst_payload_for_unknown_action() {
         let payload = analyst_payload(
             "AAPL",

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,4 +1,4 @@
-use crate::analyst::AnalystNews;
+use crate::analyst::{AnalystNews, PriceTargetAction};
 use crate::earnings::{company_name, earnings_description};
 use crate::news::NewsItem;
 use serde::Serialize;
@@ -56,11 +56,11 @@ pub fn analyst_payload(
     transparent_png: &str,
 ) -> Option<WebhookPayload> {
     let report = AnalystNews::new(headline);
-    let (emoji, color) = match report.price_target_action.to_lowercase().as_str() {
-        "lowers" => ("💔", 0xd42020),
-        "raises" => ("💚", 0x4caf50),
-        "announces" | "maintains" => return None,
-        _ => ("❓", 0),
+    let (emoji, color) = match report.price_target_action {
+        Some(PriceTargetAction::Lowers) => ("💔", 0xd42020),
+        Some(PriceTargetAction::Raises) => ("💚", 0x4caf50),
+        Some(PriceTargetAction::Announces | PriceTargetAction::Maintains) => return None,
+        None => ("❓", 0),
     };
 
     Some(WebhookPayload {
@@ -170,6 +170,18 @@ mod tests {
         .unwrap();
         assert_eq!(payload.embeds[0].title, "💚 AAPL: Apple $223.00");
         assert_eq!(payload.embeds[0].color, Some(0x4caf50));
+    }
+
+    #[test]
+    fn builds_analyst_payload_for_unknown_action() {
+        let payload = analyst_payload(
+            "AAPL",
+            "Goldman Sachs Maintains Buy on Apple, Says Fundamentals Remain Strong",
+            LOGO,
+            TRANSPARENT,
+        )
+        .unwrap();
+        assert_eq!(payload.embeds[0].color, Some(0));
     }
 
     #[test]

--- a/src/earnings.rs
+++ b/src/earnings.rs
@@ -7,10 +7,11 @@ static EARNINGS_NEWS_RE: LazyLock<Regex> = LazyLock::new(|| {
         .unwrap()
 });
 static EARNINGS_DATA_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)(EPS|Sales) ([\d\.()$KMBT]+) (\w+) ([\d\.()$KMBT]+)(?: Est(?:imate|\.)?)?")
+    Regex::new(r"(?i)(?P<kind>EPS|Sales) (?P<actual>[\d\.()$KMBT]+) (?P<result>\w+) (?P<estimate>[\d\.()$KMBT]+)(?: Est(?:imate|\.)?)?")
         .unwrap()
 });
-static COMPANY_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^(.*?) Q[1-4]").unwrap());
+static COMPANY_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(?P<company>.*?) Q[1-4]").unwrap());
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EarningsResult {
@@ -31,7 +32,7 @@ pub fn extract_earnings_data(headline: &str) -> HashMap<String, EarningsResult> 
     EARNINGS_DATA_RE
         .captures_iter(headline)
         .map(|captures| {
-            let result_type = if captures[1].eq_ignore_ascii_case("eps") {
+            let result_type = if captures["kind"].eq_ignore_ascii_case("eps") {
                 "EPS"
             } else {
                 "Sales"
@@ -39,9 +40,9 @@ pub fn extract_earnings_data(headline: &str) -> HashMap<String, EarningsResult> 
             (
                 result_type.to_string(),
                 EarningsResult {
-                    actual: captures[2].to_string(),
-                    estimate: captures[4].to_string(),
-                    beat: parse_earnings_result(&captures[3]),
+                    actual: captures["actual"].to_string(),
+                    estimate: captures["estimate"].to_string(),
+                    beat: parse_earnings_result(&captures["result"]),
                 },
             )
         })
@@ -55,7 +56,7 @@ pub fn parse_earnings_result(raw_result: &str) -> bool {
 pub fn company_name(headline: &str) -> String {
     COMPANY_RE
         .captures(headline)
-        .map(|captures| captures[1].to_string())
+        .map(|captures| captures["company"].to_string())
         .unwrap_or_default()
 }
 


### PR DESCRIPTION
Three small readability/maintainability smells in the analyst headline parser had built up: a stringly-typed price-target action compared with `.to_lowercase().as_str()`, an `AnalystNews` constructor that built a `Default` struct and then mutated it across three methods, and regex capture groups accessed by bare numeric index (`captures[1]`, `captures[2]`, ...) that silently depend on group order matching between `MAINTAINS_RE` and `ACTION_RE` even though those two regexes capture `guidance`/`stock` in different positions.

- add a `PriceTargetAction` enum (`Lowers`/`Raises`/`Announces`/`Maintains`) and store it as `Option<PriceTargetAction>` on `AnalystNews` instead of a raw `String`; `discord.rs` now matches on it exhaustively instead of lowercasing and string-matching
- rebuild `AnalystNews::new` as a pure constructor: compute all fields from the headline via free functions, then construct `Self { .. }` once, instead of `Default` + three `&mut self` mutation passes; dropped the now-unused `Default` derive
- switch every `.captures()` consumer in `analyst.rs` and `earnings.rs` to named capture groups (`&captures["firm"]`, `&captures["stock"]`, etc.) so the field mapping is self-documenting and the guidance/stock position swap between the two analyst regexes can't silently break

No behavior change — same regexes, same parsing rules, same Discord payloads. Added coverage for the "no price target action" path in both `analyst.rs` and `discord.rs`, which wasn't exercised before.

Verified with `cargo test` (36/36), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `make check`. Ran a local CodeRabbit review; both findings turned out to be pre-existing regex behavior unrelated to this diff, surfaced only by an unrealistic test headline I'd written — fixed the test headline instead of changing production regex behavior, which is out of scope here.
