### PR TITLE
build: use Hummingbird container images

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
+FROM registry.access.redhat.com/hi/go:1.26-builder AS builder
 ARG GIT_SHA=unknown
 ARG BUILD_DATE=unknown
 WORKDIR /src
@@ -7,7 +7,6 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.commit=${GIT_SHA} -X main.buildDate=${BUILD_DATE}" -o /tmp/stocknews ./cmd/stocknews
 
-FROM registry.access.redhat.com/ubi9/ubi-micro
+FROM registry.access.redhat.com/hi/static:latest
 COPY --from=builder /tmp/stocknews /usr/local/bin/stocknews
-USER 65532:65532
 CMD ["/usr/local/bin/stocknews"]

--- a/tools/coveragecheck/main_test.go
+++ b/tools/coveragecheck/main_test.go
@@ -135,8 +135,6 @@ func TestRunReturnsStatError(t *testing.T) {
 }
 
 func TestRunReturnsOpenError(t *testing.T) {
-	t.Parallel()
-
 	oldStat := statCoverageProfile
 	oldOpen := openCoverageProfile
 	t.Cleanup(func() {


### PR DESCRIPTION
## Summary

- switch the build stage to Hummingbird Go 1.26
- switch the runtime stage to Hummingbird static, which includes CA roots for TLS verification

## Tests
- make check
- podman build -t stocknews:hummingbird-go126 .
