### PR TITLE
chore: target Go 1.26

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Real-time Alpaca stock news bot that filters Benzinga Newsdesk items and sends D
 - Run local gates before committing: `make check`.
 - Use `make coverage` to enforce aggregate Go test coverage at `>=95%`.
 - Runtime: `go run ./cmd/stocknews` or `podman compose up --build`.
-- Go toolchain: `1.24.0` from `go.mod`.
+- Go toolchain: latest Go `1.26.x` from `go.mod`/`toolchain`.
 
 ## Progressive discovery
 
@@ -25,7 +25,7 @@ Read only what you need:
 - Env vars only; Discord webhooks use plural comma-separated vars: `*_WEBHOOKS`.
 - Keep tests next to the package they cover.
 - Prefer simple structs/functions; add custom error types only when callers need to match errors.
-- Container builds use Hummingbird Go images: `registry.access.redhat.com/ubi9/go-toolset:1.24` for build, `registry.access.redhat.com/ubi9/ubi-micro` for runtime.
+- Container builds use Hummingbird Go images: `registry.access.redhat.com/hi/go:1.26-builder` for build, `registry.access.redhat.com/hi/static:latest` for runtime.
 - Keep action versions pinned to commit SHAs.
 - Use `mvdan.cc/gofumpt` for formatting and `github.com/golangci/golangci-lint/v2` for lint, including exported comment enforcement via `revive`.
 - Do not reintroduce legacy non-Go tooling.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/major/stocknews
 
-go 1.25.0
+go 1.26.0
+
+toolchain go1.26.5
 
 require (
 	github.com/alpacahq/alpaca-trade-api-go/v3 v3.11.0

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>major/renovate-config"]
+  "extends": ["github>major/renovate-config"],
+  "constraints": {
+    "go": "1.26"
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "matchDepTypes": ["golang"],
+      "rangeStrategy": "bump"
+    }
+  ]
 }


### PR DESCRIPTION
Target Go 1.26 across the repo.

- set go.mod to Go 1.26 with an explicit toolchain
- configure Renovate to keep the Go directive on the 1.26 line
- update agent docs for the current Go/container expectations

Tested:
- make check
